### PR TITLE
fix not existing mail throwing exception

### DIFF
--- a/rest.py
+++ b/rest.py
@@ -42,6 +42,9 @@ class SendEmail(Resource):
   def get(self, id):
     email = Email.by_id(id)
 
+    if email is None:
+        abort(404, message="Mail not found")
+
     return email.as_dict()
 
   def post(self,id=None):

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -107,3 +107,8 @@ def test_multiple_email_invalid_fails_validation():
   assert api_json_result['message'][0]['field'] == 'to'
   assert api_json_result['message'][0]['parsed'] == 'bcambel@gmail.com'
   assert api_json_result['message'][0]['unparsed'] == 'bcambel@'
+
+def test_non_existing_mail_should_return_404():
+  api_result = app_client.get("/mail/x")
+
+  assert api_result.status == "404 NOT FOUND"


### PR DESCRIPTION
a non existing mail query returns a None object then we called .as_dict() which caused the exception. Check if the return is None and if it is, abort request with 404
